### PR TITLE
feat: 실시간 데이터 처리 스파크 애플리케이션 추가

### DIFF
--- a/Spark_Application/spark_streaming_kafka_to_s3.py
+++ b/Spark_Application/spark_streaming_kafka_to_s3.py
@@ -1,9 +1,10 @@
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, from_json
-from pyspark.sql.types import StructType, StructField, StringType
+from pyspark.sql.types import StructType, StructField, StringType, TimestampType
 from pyspark.sql.functions import sha2
 import os
 import sys
+from datetime import datetime
 
 os.environ['PYSPARK_PYTHON'] = sys.executable
 os.environ['PYSPARK_DRIVER_PYTHON'] = sys.executable
@@ -16,21 +17,24 @@ spark = SparkSession.builder.appName("League Of Legend Player Streaming") \
   .enableHiveSupport() \
   .getOrCreate()
 
+kafka_bootstrap_server = spark.conf.get("spark.kafka.bootstrap.servers")
+kafka_topic = spark.conf.get("spark.kafka.topic")
+
 kafkaStream = spark \
   .readStream \
   .format("kafka") \
-  .option("kafka.bootstrap.servers", "<ip>:<port>") \
-  .option("subscribe", "<topic>") \
+  .option("kafka.bootstrap.servers", kafka_bootstrap_server) \
+  .option("subscribe", kafka_topic) \
   .load()
 
 schema = StructType([
-  StructField("createRoomDate", StringType(), True),
+  StructField("createRoomDate", TimestampType(), True),
   StructField("method", StringType(), True),
   StructField("ingametime", StringType(), True),
   StructField("ip", StringType(), True),
   StructField("deathCount", StringType(), True),
   StructField("roomID", StringType(), True),
-  StructField("datetime", StringType(), True),
+  StructField("datetime", TimestampType(), True),
   StructField("x", StringType(), True),
   StructField("y", StringType(), True),
   StructField("inputkey", StringType(), True),
@@ -43,19 +47,48 @@ jsonParsedStream = kafkaStream.selectExpr("CAST(value As STRING)") \
   .select(from_json(col("value"), schema).alias("data")) \
   .select("data.*")
 
-jsonParsedStream = jsonParsedStream.withColumn("account_sha2", sha2(col("account"), 256))
-jsonParsedStream = jsonParsedStream.drop("account")
+jsonParsedStream = jsonParsedStream \
+  .withColumn("create_room_date", col("createRoomDate")) \
+  .withColumn("current_time", col("ingametime")) \
+  .withColumn("death_count", col("deathCount")) \
+  .withColumn("room_id", col("roomID")) \
+  .withColumn("death_count", col("createRoomDate").cast("int")) \
+  .withColumn("x", col("x").cast("int")) \
+  .withColumn("y", col("y").cast("int")) \
+  .withColumn("status", col("status").cast("int")) \
+  .drop("createRoomDate").drop("ingametime").drop("deathCount").drop("roomID")
 
-transformedPlayerLogs = jsonParsedStream.toDF("createRoomDate", "method", "ingametime", "ip",
-                           "deathCount", "roomID", "datetime", "x", "y",
-                           "inputkey", "champion", "status", "account_sha2")
+jsonParsedStream = jsonParsedStream \
+  .withColumn("encrypted_account", sha2(col("account"), 256)) \
+  .drop("account") \
+  .drop("ip")
+
+jsonParsedStream = jsonParsedStream.select("create_room_date",
+                                           "method",
+                                           "current_time",
+                                           "death_count",
+                                           "room_id",
+                                           "datetime",
+                                           "encrypted_account",
+                                           "x",
+                                           "y",
+                                           "inputkey",
+                                           "champion",
+                                           "status")
+
+transformedPlayerLogs = jsonParsedStream.toDF("create_room_date", "method",
+                                              "current_time", "death_count",
+                                              "room_id", "datetime",
+                                              "encrypted_account", "x", "y",
+                                              "inputkey", "champion", "status")
+
 
 playerLogsStreamWriter = transformedPlayerLogs.writeStream \
   .trigger(processingTime='1 minute') \
   .outputMode("append") \
   .format("json") \
-  .option("path", "s3://sjm-simple-data/bronzelayer/playerlogs/") \
-  .option("checkpointLocation", "s3://sjm-simple-data/checkpoint/Riot/") \
+  .option("path", "s3://sjm-simple-data/bronzelayer/" + str(datetime.today().strftime("%Y-%m-%d"))) \
+  .option("checkpointLocation","s3://sjm-simple-data/checkpoint/" + str(datetime.today().strftime("%Y-%m-%d"))) \
   .queryName("query_playerLogs") \
   .start()
 

--- a/Spark_Application/spark_streaming_kafka_to_s3.py
+++ b/Spark_Application/spark_streaming_kafka_to_s3.py
@@ -1,10 +1,9 @@
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, from_json
-from pyspark.sql.types import StructType, StructField, StringType, TimestampType
+from pyspark.sql.types import StructType, StructField, StringType, TimestampType,DateType
 from pyspark.sql.functions import sha2
 import os
 import sys
-from datetime import datetime
 
 os.environ['PYSPARK_PYTHON'] = sys.executable
 os.environ['PYSPARK_DRIVER_PYTHON'] = sys.executable
@@ -28,7 +27,7 @@ kafkaStream = spark \
   .load()
 
 schema = StructType([
-  StructField("createRoomDate", TimestampType(), True),
+  StructField("createRoomDate", DateType(), True),
   StructField("method", StringType(), True),
   StructField("ingametime", StringType(), True),
   StructField("ip", StringType(), True),
@@ -87,8 +86,9 @@ playerLogsStreamWriter = transformedPlayerLogs.writeStream \
   .trigger(processingTime='1 minute') \
   .outputMode("append") \
   .format("json") \
-  .option("path", "s3://sjm-simple-data/bronzelayer/" + str(datetime.today().strftime("%Y-%m-%d"))) \
-  .option("checkpointLocation","s3://sjm-simple-data/checkpoint/" + str(datetime.today().strftime("%Y-%m-%d"))) \
+  .option("path", "s3://sjm-simple-data/bronze_riot/playerlogs/") \
+  .option("checkpointLocation","s3://sjm-simple-data/checkpoint/bronze_riot/playerlogs/") \
+  .partitionBy("create_room_date") \
   .queryName("query_playerLogs") \
   .start()
 

--- a/Spark_Application/spark_streaming_kafka_to_s3.py
+++ b/Spark_Application/spark_streaming_kafka_to_s3.py
@@ -1,0 +1,62 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, from_json
+from pyspark.sql.types import StructType, StructField, StringType
+from pyspark.sql.functions import sha2
+import os
+import sys
+
+os.environ['PYSPARK_PYTHON'] = sys.executable
+os.environ['PYSPARK_DRIVER_PYTHON'] = sys.executable
+
+spark = SparkSession.builder.appName("League Of Legend Player Streaming") \
+  .master("yarn") \
+  .config("spark.jars.packages",
+          "org.apache.spark:spark-sql-kafka-0-10_2.12:3.3.0,org.apache.spark:spark-streaming-kafka-0-10_2.12:3.3.0") \
+  .config("spark.home", "/usr/lib/spark") \
+  .enableHiveSupport() \
+  .getOrCreate()
+
+kafkaStream = spark \
+  .readStream \
+  .format("kafka") \
+  .option("kafka.bootstrap.servers", "<ip>:<port>") \
+  .option("subscribe", "<topic>") \
+  .load()
+
+schema = StructType([
+  StructField("createRoomDate", StringType(), True),
+  StructField("method", StringType(), True),
+  StructField("ingametime", StringType(), True),
+  StructField("ip", StringType(), True),
+  StructField("deathCount", StringType(), True),
+  StructField("roomID", StringType(), True),
+  StructField("datetime", StringType(), True),
+  StructField("x", StringType(), True),
+  StructField("y", StringType(), True),
+  StructField("inputkey", StringType(), True),
+  StructField("account", StringType(), True),
+  StructField("champion", StringType(), True),
+  StructField("status", StringType(), True)
+])
+
+jsonParsedStream = kafkaStream.selectExpr("CAST(value As STRING)") \
+  .select(from_json(col("value"), schema).alias("data")) \
+  .select("data.*")
+
+jsonParsedStream = jsonParsedStream.withColumn("account_sha2", sha2(col("account"), 256))
+jsonParsedStream = jsonParsedStream.drop("account")
+
+transformedPlayerLogs = jsonParsedStream.toDF("createRoomDate", "method", "ingametime", "ip",
+                           "deathCount", "roomID", "datetime", "x", "y",
+                           "inputkey", "champion", "status", "account_sha2")
+
+playerLogsStreamWriter = transformedPlayerLogs.writeStream \
+  .trigger(processingTime='1 minute') \
+  .outputMode("append") \
+  .format("json") \
+  .option("path", "s3://sjm-simple-data/bronzelayer/playerlogs/") \
+  .option("checkpointLocation", "s3://sjm-simple-data/checkpoint/Riot/") \
+  .queryName("query_playerLogs") \
+  .start()
+
+playerLogsStreamWriter.awaitTermination()


### PR DESCRIPTION
### 변경 사항 개요
- Spark Streaming으로 Kafka를 읽어 데이터 중 개인을 식별할 수 있는 유저명을 SHA-256를 적용에 암호화(가명화) 작업을 하고 최종적으로 S3에 저장합니다

### 관련 이슈
  - #17 

### 변경 사항 상세 설명
1. Zeppelin 환경에서 작성했던 코드를 spark-submit 할 수 있게 작성하였습니다.
2. 개인을 식별 할 수 있는 유저명을 SHA-256을 적용 해 데이터 암호화(가명화)를 적용했습니다. 이로써 접근한 사용자는 식별할 수 없게 됩니다.
3. 기존은 txt파일로 저장했지만, 현재는 json 파일 형식으로 저장을 진행합니다. 텍스트로 저장하면 데이터를 사용할 때 추가 변환 작업을 요구하게 됩니다. 데이터의 품질이 낮아진다 판단해 json 형식으로 저장하도록 변경하였습니다.

### 테스트
- 직접 수동으로 테스트를 진행했습니다. 직접 클러스터에 spark-submit으로 스파크 어플리케이션을 제출 후, 구조적 스트리밍이 작동하면서 최종적으로 암호화 된 데이터를 저장하는 것 까지 완료하였습니다.

**실행 명령**
> spark-submit  \
--master yarn \
 --deploy-mode cluster \
--conf spark.kafka.bootstrap.servers="airflow-mysql-01:29092" \
--conf spark.kafka.topic="lol" \ 
--packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.3.0,org.apache.spark:spark-streaming-kafka-0-10_2.12:3.3.0 \ 
./spark_streaming_kafka_to_s3.py

### 추가 고려 사항
- 소스에 옵션으로 spark.jars.packages를 작성했지만, spark-submit할 때 인식하지 못하는 것 같습니다. 그래서 제출할 때 패키지의 정보도 같이 입력해야 합니다.

### 스크린샷 (필요시)
- 변경된 UI가 있는 경우, 전후의 스크린샷을 첨부하세요.
- 변경 사항을 시각적으로 보여줄 수 있는 자료를 제공하세요.

### 체크리스트
- [X] 코드가 정상적으로 컴파일되고 빌드됩니다.
- [ ] 모든 테스트가 통과되었습니다.
- [ ] 관련 문서가 업데이트되었습니다.
- [X] 팀원들이 리뷰할 준비가 되었습니다.

### 기타
- 추가로 공유하고 싶은 내용이나 문의 사항이 있으면 작성하세요.
