### PR TITLE
feat: Kafka Lag 모니터링 시스템 구축

### DIFF
--- a/Spark_Application/spark_batch_gold.py
+++ b/Spark_Application/spark_batch_gold.py
@@ -1,0 +1,74 @@
+import os
+import sys
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, avg, count, when, max, round, stddev
+from pyspark.sql.types import DateType
+
+os.environ["PYSPARK_PYTHON"] = sys.executable
+os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
+
+spark = (
+    SparkSession.builder.appName("League Of Legend Player Batch Silver Layer")
+    .master("yarn")
+    .config("spark.home", "/usr/lib/spark")
+    .enableHiveSupport()
+    .getOrCreate()
+)
+
+
+filter_time = spark.conf.get("spark.config.partition.time")
+
+silver_playerlogs_df = spark.read.parquet(
+    "s3://sjm-simple-data/silver_analysis_riot/"
+).filter("create_room_date='" + filter_time + "'")
+
+
+average_death_and_time = silver_playerlogs_df.groupBy(
+    "encrypted_account", "champion", "create_room_date"
+).agg(
+    avg("death_count").alias("average_deaths"),
+    avg("current_time").alias("average_game_time"),
+)
+
+room_end_time = silver_playerlogs_df.groupBy("room_id", "create_room_date").agg(
+    max("current_time").alias("end_time")
+)
+
+key_used_per = (
+    silver_playerlogs_df.groupBy("champion", "create_room_date")
+    .agg(
+        count(when(col("inputkey") == "alt", True)).alias("used"),
+        count("*").alias("total"),
+    )
+    .withColumn("total_q", round(col("used") / col("total"), 2))
+)
+
+champion_death_count = (
+    silver_playerlogs_df.groupBy("room_id", "champion", "create_room_date")
+    .agg(max("death_count").alias("death_count"))
+    .orderBy("room_id")
+)
+
+room_champion_xy = silver_playerlogs_df.groupBy(
+    "room_id", "encrypted_account", "champion", "create_room_date"
+).agg(stddev(col("x")), stddev(col("y")))
+
+
+average_death_and_time.write.format("parquet").mode("append").partitionBy(
+    "create_room_date"
+).save("s3://sjm-simple-data/gold_riot/average_death_and_time/")
+
+room_end_time.write.format("parquet").mode("append").partitionBy(
+    "create_room_date"
+).save("s3://sjm-simple-data/gold_riot/room_end_time/")
+key_used_per.write.format("parquet").mode("append").partitionBy(
+    "create_room_date"
+).save("s3://sjm-simple-data/gold_riot/key_used_per/")
+champion_death_count.write.format("parquet").mode("append").partitionBy(
+    "create_room_date"
+).save("s3://sjm-simple-data/gold_riot/champion_death_count/")
+room_champion_xy.write.format("parquet").mode("append").partitionBy(
+    "create_room_date"
+).save("s3://sjm-simple-data/gold_riot/room_champion_xy/")
+
+spark.stop()

--- a/Spark_Application/spark_batch_silver_analysis.py
+++ b/Spark_Application/spark_batch_silver_analysis.py
@@ -1,0 +1,73 @@
+import os
+import sys
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, isnan, when, count, isnull
+from pyspark.sql.types import IntegerType, TimestampType, DateType
+
+
+os.environ["PYSPARK_PYTHON"] = sys.executable
+os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
+
+spark = (
+    SparkSession.builder.appName("League Of Legend Player Batch Silver Layer")
+    .master("yarn")
+    .config("spark.home", "/usr/lib/spark")
+    .enableHiveSupport()
+    .getOrCreate()
+)
+
+bronze_playlogs_json = spark.read.json("s3://sjm-simple-data/bronze_riot/playerlogs/*")
+
+transformed_playerlogs = bronze_playlogs_json.withColumn(
+    "current_time", col("current_time").cast(IntegerType())
+).withColumn("datetime", col("datetime").cast(TimestampType()))
+
+# transformed_playerlogs.select(
+#    [count(when(isnull(df1), df1)).alias(df1) for df1 in transformed_playerlogs.columns]
+# ).show()
+
+filtered_playlogs_nullcheck = (
+    transformed_playerlogs.filter(
+        ~(
+            (transformed_playerlogs["champion"] == "")
+            | (transformed_playerlogs["champion"].isNull())
+            | isnan(bronze_playlogs_json["champion"])
+        )
+    )
+    .filter(
+        ~(
+            (transformed_playerlogs["encrypted_account"] == "")
+            | (transformed_playerlogs["encrypted_account"].isNull())
+            | isnan(bronze_playlogs_json["encrypted_account"])
+        )
+    )
+    .filter(
+        ~(
+            (transformed_playerlogs["room_id"] == "")
+            | (transformed_playerlogs["room_id"].isNull())
+            | isnan(bronze_playlogs_json["room_id"])
+        )
+    )
+    .filter(~(isnan(bronze_playlogs_json["current_time"])))
+    .filter(~(isnan(bronze_playlogs_json["datetime"])))
+)
+
+# filtered_playlogs_nullcheck.select(
+#    [count(when(isnull(df1), df1)).alias(df1) for df1 in transformed_playerlogs.columns]
+# ).show()
+
+analysis_data = (
+    filtered_playlogs_nullcheck.withColumn("x+y", col("x") + col("y"))
+    .withColumn("buy", when(col("method") == "/buyItem", 1).otherwise(0))
+    .orderBy("room_id", "current_time")
+)
+
+analysis_data = analysis_data.withColumn(
+    "create_room_date", col("datetime").cast(DateType())
+)
+
+analysis_data.write.format("parquet").mode("append").partitionBy(
+    "create_room_date"
+).save("s3://sjm-simple-data/silver_analysis_riot/playerlogs")
+
+spark.stop()

--- a/Spark_Application/spark_batch_silver_train.py
+++ b/Spark_Application/spark_batch_silver_train.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, isnan, when, count, isnull
+from pyspark.ml.feature import StringIndexer
+from pyspark.sql.types import DateType
+
+os.environ["PYSPARK_PYTHON"] = sys.executable
+os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
+
+spark = (
+    SparkSession.builder.appName("League Of Legend Player Batch Silver Layer")
+    .master("yarn")
+    .config("spark.home", "/usr/lib/spark")
+    .enableHiveSupport()
+    .getOrCreate()
+)
+
+bronze_playlogs_json = spark.read.json("s3://sjm-simple-data/bronze_riot/playerlogs/*")
+
+
+chamion_indexer = StringIndexer(
+    inputCols=["champion", "room_id", "inputkey"],
+    outputCols=["cahmpion_indexed", "room_indexed", "inputkey_indexed"],
+)
+
+chamion_indexer_model = chamion_indexer.fit(bronze_playlogs_json)
+final_data_with_transform = chamion_indexer_model.transform(bronze_playlogs_json)
+
+label_add_playlogs = final_data_with_transform.withColumn(
+    "label", when(col("champion") == "VIKTOR", 1).otherwise(0)
+).withColumn("create_room_date", col("datetime").cast(DateType()))
+
+train_data = label_add_playlogs.withColumn("x+y", col("x") + col("y")).select(
+    "cahmpion_indexed",
+    "datetime",
+    "encrypted_account",
+    "inputkey_indexed",
+    "x",
+    "y",
+    "label",
+    "create_room_date",
+)
+
+train_data.write.format("parquet").mode("append").partitionBy("create_room_date").save(
+    "s3://sjm-simple-data/silver_train_riot/playerlogs"
+)
+
+spark.stop()

--- a/airflow/dags/airflow_silver_analysis.py
+++ b/airflow/dags/airflow_silver_analysis.py
@@ -175,7 +175,7 @@ with DAG(
     default_args=default_args,
     dagrun_timeout=timedelta(hours=1),
     start_date=datetime(2024, 9, 7),
-    schedule_interval=None,
+    schedule_interval="0 7 * * *",
 ) as dag:
     create_cluster = EmrCreateJobFlowOperator(
         task_id="create_emr_cluster",

--- a/airflow/dags/airflow_silver_analysis.py
+++ b/airflow/dags/airflow_silver_analysis.py
@@ -1,0 +1,207 @@
+from datetime import timedelta, datetime
+
+from airflow import DAG
+from airflow.providers.amazon.aws.operators.emr import (
+    EmrCreateJobFlowOperator,
+    EmrAddStepsOperator,
+)
+from airflow.providers.amazon.aws.sensors.emr import EmrStepSensor
+from pendulum import yesterday
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email": ["test1234@naver.com"],
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 3,
+    "retry_delay": timedelta(minutes=10),
+    # 'queue': 'bash_queue',
+    # 'pool': 'backfill',
+    # 'priority_weight': 10,
+    # 'end_date': datetime(2016, 1, 1),
+    # 'wait_for_downstream': False,
+    # 'dag': dag,
+    # 'sla': timedelta(hours=2),
+    # 'execution_timeout': timedelta(seconds=300),
+    # 'on_failure_callback': some_function,
+    # 'on_success_callback': some_other_function,
+    # 'on_retry_callback': another_function,
+    # 'sla_miss_callback': yet_another_function,
+    # 'trigger_rule': 'all_success'
+}
+
+JOB_FLOW_OVERRIDES = {
+    "Name": "Airflow-Batch-Scheduling",
+    "LogUri": "<s3:url>",
+    "ReleaseLabel": "emr-6.8.0",
+    "ServiceRole": "<aws:service-role>",
+    "JobFlowRole": "<aws:jobflow-role>",
+    "Applications": [{"Name": "Hadoop"}, {"Name": "Spark"}],
+    "ManagedScalingPolicy": {
+        "ComputeLimits": {
+            "UnitType": "Instances",
+            "MinimumCapacityUnits": 1,
+            "MaximumCapacityUnits": 5,
+            "MaximumOnDemandCapacityUnits": 5,
+            "MaximumCoreCapacityUnits": 5,
+        }
+    },
+    "Instances": {
+        "Ec2KeyName": "emr-pem",
+        "Ec2SubnetId": "<aws:subnet-id>",
+        "EmrManagedMasterSecurityGroup": "<aws:master_security_group>",
+        "EmrManagedSlaveSecurityGroup": "<aws:slave_security_group>",
+        "ServiceAccessSecurityGroup": "",
+        "AdditionalMasterSecurityGroups": [""],
+        "AdditionalSlaveSecurityGroups": [""],
+        "InstanceGroups": [
+            {
+                "Name": "",
+                "InstanceRole": "MASTER",
+                "InstanceType": "m5.xlarge",
+                "InstanceCount": 1,
+                "EbsConfiguration": {
+                    "EbsBlockDeviceConfigs": [
+                        {
+                            "VolumeSpecification": {
+                                "VolumeType": "gp3",
+                                "SizeInGB": 32,
+                            },
+                            "VolumesPerInstance": 2,
+                        }
+                    ]
+                },
+            },
+            {
+                "Name": "",
+                "InstanceRole": "CORE",
+                "InstanceType": "m5.xlarge",
+                "InstanceCount": 1,
+                "EbsConfiguration": {
+                    "EbsBlockDeviceConfigs": [
+                        {
+                            "VolumeSpecification": {
+                                "VolumeType": "gp3",
+                                "SizeInGB": 32,
+                            },
+                            "VolumesPerInstance": 2,
+                        }
+                    ]
+                },
+            },
+        ],
+        "KeepJobFlowAliveWhenNoSteps": False,
+        "TerminationProtected": False,
+    },
+    "Configurations": [
+        {
+            "Classification": "hive-site",
+            "Properties": {
+                "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+            },
+        },
+        {
+            "Classification": "spark-hive-site",
+            "Properties": {
+                "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+            },
+        },
+    ],
+    "EbsRootVolumeSize": 30,
+    "Tags": [{"Key": "Name", "Value": "airflow_silver_analysis"}],
+    "ScaleDownBehavior": "TERMINATE_AT_TASK_COMPLETION",
+}
+
+today = datetime.date.today()
+yesterday = today - timedelta(days=1)
+
+spark_steps = [
+    {
+        "Name": "spark_batch_silver_analysis",
+        "ActionOnFailure": "CONTINUE",
+        "HadoopJarStep": {
+            "Jar": "command-runner.jar",
+            "Args": [
+                "spark-submit",
+                "--deploy-mode",
+                "cluster",
+                "--master",
+                "yarn",
+                "--conf",
+                f"spark.config.partition.time={yesterday}",
+                "s3://sjm-simple-data/app/spark_batch_silver_analysis.py",
+            ],
+        },
+    },
+    {
+        "Name": "spark_batch_silver_layer_train",
+        "ActionOnFailure": "CONTINUE",
+        "HadoopJarStep": {
+            "Jar": "command-runner.jar",
+            "Args": [
+                "spark-submit",
+                "--deploy-mode",
+                "cluster",
+                "--master",
+                "yarn",
+                "--conf",
+                f"spark.config.partition.time={yesterday}",
+                "s3://sjm-simple-data/app/spark_batch_silver_train.py",
+            ],
+        },
+    },
+    {
+        "Name": "spark_batch_gold_layer",
+        "ActionOnFailure": "CONTINUE",
+        "HadoopJarStep": {
+            "Jar": "command-runner.jar",
+            "Args": [
+                "spark-submit",
+                "--deploy-mode",
+                "cluster",
+                "--master",
+                "yarn",
+                "--conf",
+                f"spark.config.partition.time={yesterday}",
+                "s3://sjm-simple-data/app/spark_batch_gold.py",
+            ],
+        },
+    },
+]
+
+with DAG(
+    dag_id="airflow-emr-batch",
+    default_args=default_args,
+    dagrun_timeout=timedelta(hours=1),
+    start_date=datetime(2024, 9, 7),
+    schedule_interval=None,
+) as dag:
+    create_cluster = EmrCreateJobFlowOperator(
+        task_id="create_emr_cluster",
+        job_flow_overrides=JOB_FLOW_OVERRIDES,
+        aws_conn_id="aws_default",
+        emr_conn_id=None,
+        region_name="ap-northeast-2",
+    )
+
+    add_steps = EmrAddStepsOperator(
+        task_id="add_spark_steps",
+        job_flow_id='{{ task_instance.xcom_pull(task_ids="create_emr_cluster", key="return_value") }}',
+        steps=spark_steps,
+        aws_conn_id="aws_default",
+    )
+
+    step_sensors = []
+    for index in range(len(spark_steps)):
+        sensor = EmrStepSensor(
+            task_id=f"step_sensor_{index+1}",
+            job_flow_id='{{ task_instance.xcom_pull(task_ids="create_emr_cluster", key="return_value") }}',
+            step_id='{{ task_instance.xcom_pull(task_ids="add_spark_steps", key="return_value")[0] }}',
+            aws_conn_id="aws_default",
+        )
+        step_sensors.append(sensor)
+
+    create_cluster >> add_steps
+    for sensor in step_sensors:
+        add_steps >> sensor

--- a/kafka/kafka-docker-compose.yml
+++ b/kafka/kafka-docker-compose.yml
@@ -7,8 +7,8 @@ services:
     hostname: kafka-worker-01
     container_name: kafka-worker-01
     ports:
-      - 9092:9092
-      - 29092:29092
+      - "9092:9092"
+      - "29092:29092"
     environment:
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-worker-01:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
@@ -40,14 +40,14 @@ services:
       - kafka-worker-01:/kafka
     networks:
       - backend
-        
-  kafka-worker-02:                                         
+
+  kafka-worker-02:
     image: confluentinc/cp-kafka:7.3.2
     hostname: kafka-worker-02
     container_name: kafka-worker-02
     ports:
-      - 9093:9093
-      - 29093:29093                                                                                                           
+      - "9093:9093"
+      - "29093:29093"
     environment:
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-worker-02:19093,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
@@ -81,13 +81,13 @@ services:
       - backend
 
 
-  kafka-worker-03:                                                                                                                    
+  kafka-worker-03:
     image: confluentinc/cp-kafka:7.3.2
     hostname: kafka-worker-03
     container_name: kafka-worker-03
     ports:
-      - 9094:9094
-      - 29094:29094                                                                                                                
+      - "9094:9094"
+      - "29094:29094"
     environment:
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-worker-03:19094,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
@@ -130,10 +130,19 @@ services:
         constraints:
           - node.role == manager
     ports:
-      - 9001:9000
+      - "9001:9000"
     networks:
       - backend
 
+  kafka-exporter:
+    image: danielqsj/kafka-exporter
+    hostname: kafka-exporter
+    ports:
+      - "9308:9308"
+    command: [ "--kafka.server=kafka-worker-01:19092", "--kafka.server=kafka-worker-02:19093", "--kafka.server=kafka-worker-03:19094" ]
+    restart: always
+    networks:
+      - backend
 volumes:
   kafka-worker-01-log:
   kafka-worker-02-log:


### PR DESCRIPTION
다음과 같은 이유로 모니터링 시스템을 구축했습니다. #26 

# 성능 지표

## 가상의 플레이어가 100명일 때
![모니터링_시스템_100명](https://github.com/user-attachments/assets/4dc6a621-b757-4026-8439-fb8ec5302472)

| Message in per second| Message in per minute | Lag by Consumer Group |Message consume per minute|
| ------------- | ------------- |------------|-----------|
| 10~ 11.6  | 500 ~  657 | 5 ~ 23| 580 ~ 667|



## 가상의 플레이어가 500명일 때
![모니터링_시스템_100명](https://github.com/user-attachments/assets/4dc6a621-b757-4026-8439-fb8ec5302472)

| Message in per second| Message in per minute | Lag by Consumer Group |Message consume per minute|
| ------------- | ------------- |------------|-----------|
| 25 ~ 30  | 1.5k ~ 1.7k | 30 ~ 48 | 1.64k|

## Yarn의 리소스
![500명_yarn리소스](https://github.com/user-attachments/assets/836c8227-8760-4e10-a49e-864f40ede278)

500명일 때 Yarn은 해당 어플리케이션의 모든 리소스를 할당했습니다. 하나의 클러스터에서 하나의 어플리케이션이 모든 자원을 할당 받는 상황은 좋지 않은 상황이라고 판단하고 있습니다. 할당된 자원을 온전히 사용하고 있는지 확인하고, 잘 사용하고 있다면 새로운 노드를 추가하거나, 온전히 사용하지 않는다면 리소스를 제한하는 방식의 유연한 운영 방식이 필요하다고 생각합니다.

