### PR TITLE
fix: 버그 수정

### DIFF
--- a/LoL_PlayerEventGenertor/src/main/java/player/Play.java
+++ b/LoL_PlayerEventGenertor/src/main/java/player/Play.java
@@ -94,11 +94,12 @@ public class Play implements Runnable {
             String key = getPlayerInputKey();
             Integer status = getStatus();
 
-            if (champion.equals("viktor")) {
+            if (champion.equals("VIKTOR")) {
                 x_direction = getMouseX_Viktor();
                 y_direction = getMouseY_Viktor();
                 printPlayerLog(sessionRoomID, createRoomDate, ipAddr, account, champion, method,
-                    offsetDateTime, x_direction, y_direction, key, status, deathCount, runTime_seconds,
+                    offsetDateTime, x_direction, y_direction, key, status, deathCount,
+                    runTime_seconds,
                     producer);
             } else if (method.equals("/wait")) {
                 printPlayerLog(sessionRoomID, createRoomDate, ipAddr, account, champion, method,
@@ -106,17 +107,20 @@ public class Play implements Runnable {
             } else if (rand.nextDouble() > 0.97 && itemCount < 6) {
                 itemCount += 1;
                 printPlayerLog(sessionRoomID, createRoomDate, ipAddr, account, champion, "/buyItem",
-                    offsetDateTime, x_direction, y_direction, key, status, deathCount, runTime_seconds,
+                    offsetDateTime, x_direction, y_direction, key, status, deathCount,
+                    runTime_seconds,
                     producer);
             } else if (status == 1) {
                 printPlayerLog(sessionRoomID, createRoomDate, ipAddr, account, champion, method,
-                    offsetDateTime, x_direction, y_direction, key, status, deathCount, runTime_seconds,
+                    offsetDateTime, x_direction, y_direction, key, status, deathCount,
+                    runTime_seconds,
                     producer);
                 status = 0;
                 deathCount += 1;
             } else {
                 printPlayerLog(sessionRoomID, createRoomDate, ipAddr, account, champion, method,
-                    offsetDateTime, x_direction, y_direction, key, status, deathCount, runTime_seconds,
+                    offsetDateTime, x_direction, y_direction, key, status, deathCount,
+                    runTime_seconds,
                     producer);
             }
         }

--- a/LoL_PlayerEventGenertor/src/main/java/player/Room.java
+++ b/LoL_PlayerEventGenertor/src/main/java/player/Room.java
@@ -101,7 +101,7 @@ public class Room implements Runnable {
      */
     private static String getIpAddr() {
         while (true) {
-            String ipAddr = "192.168.0." + rand.nextInt(256);
+            String ipAddr = "192.168."+  rand.nextInt(256)+ "." + rand.nextInt(256);
 
             if (!ipSet.contains(ipAddr)) {
                 ipSet.add(ipAddr);


### PR DESCRIPTION
## 다음과 같은 버그가 발생했습니다.

1. 가상의 사용자 수가 255명 이상부터 Log가 발생하는 속도가 일정해짐
2. VIKTOR 챔피언의 마우스 좌표값이 다른 플레이어와 같이 정상적인 좌표를 가짐

## 해결

1.기존의 랜덤으로 Ip를 생성하는 함수는 IP의 마지막 주소만 0~255의 값을 고정해서 255 명 이상부턴 로그의 수가 일정해 졌기 
  때문에 과부하 테스트 및 데이터 수집에 문제가 생겼습니다.

  현재 세번째와 네번째를 랜덤으로 설정 해 약 6만 5천의 경우의 수를 가지도록 했습니다.  이를 통해 5000명을 기준, 한번의 실행으로 1,300,000개의 데이터를 생성합니다.

2. 챔피언의 이름이 대문자에 맞춰서 변경했습니다.

